### PR TITLE
remove memory leak and error

### DIFF
--- a/maze.js
+++ b/maze.js
@@ -168,7 +168,7 @@ solve(maze, 0, 0, path)
 path = path.reverse()
 
 setTimeout(()=>{
-    let ti = 0, tj = 0, j = 0
+    let ti = 0, tj = 0, j = 1
     setInterval(() => {
         if(j < path.length){
             let direction = path[j]

--- a/queue.js
+++ b/queue.js
@@ -1,17 +1,16 @@
 function Queue(){
 	this.q = []
-	this.ind = 0
+	
 	this.push = (elem) => {
 		this.q.push(elem)
 	}
 	this.pop = () => {
-		this.ind += 1
-		return this.q[this.ind-1]
+		return this.q.shift()
 	}
 	this.ref = () => {
-		return this.q[this.ind]
+		return this.q[0]
 	}
 	this.size = () => {
-		return this.q.length - this.ind
+		return this.q.length
 	}
 }


### PR DESCRIPTION
1. Implementing of Queue using index has memory leak. Because JS' garbage collector may think elements removed from queue are also reachable using index. I used Vanilla JS' shift function. 

If you trying to keep using index in your queue, you can assign null to removed element. Although It is not a best implementation, It can make garbage collector detect the element.

2. There was off-by-one error in your maze.js code.